### PR TITLE
Add JSession management

### DIFF
--- a/Docs/en-US/Close-JSession.md
+++ b/Docs/en-US/Close-JSession.md
@@ -1,0 +1,60 @@
+---
+external help file: JiraModule.dll-Help.xml
+Module Name: jira
+online version:
+schema: 2.0.0
+---
+
+# Close-JSession
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Close-JSession [[-Session] <JSession>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### -Session
+{{ Fill Session Description }}
+
+```yaml
+Type: JSession
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### JiraModule.JSession
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Docs/en-US/Get-JSession.md
+++ b/Docs/en-US/Get-JSession.md
@@ -1,0 +1,45 @@
+---
+external help file: JiraModule.dll-Help.xml
+Module Name: jira
+online version:
+schema: 2.0.0
+---
+
+# Get-JSession
+
+## SYNOPSIS
+{{ Fill in the Synopsis }}
+
+## SYNTAX
+
+```
+Get-JSession [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:> {{ Add example code here }}
+```
+
+{{ Add example description here }}
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Docs/en-US/Invoke-JIssueTransition.md
+++ b/Docs/en-US/Invoke-JIssueTransition.md
@@ -12,14 +12,14 @@ schema: 2.0.0
 
 ## SYNTAX
 
-### IssueID (Default)
+### InputObject (Default)
 ```
-Invoke-JIssueTransition [-Key] <String[]> [-TransitionTo] <String> [<CommonParameters>]
+Invoke-JIssueTransition -InputObject <Issue> [-TransitionTo] <String> [<CommonParameters>]
 ```
 
-### InputObject
+### IssueID
 ```
-Invoke-JIssueTransition [-InputObject] <Issue> [-TransitionTo] <String> [<CommonParameters>]
+Invoke-JIssueTransition [-Key] <String[]> [-TransitionTo] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,7 +45,7 @@ Parameter Sets: InputObject
 Aliases:
 
 Required: True
-Position: 0
+Position: Named
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False

--- a/Docs/en-US/Open-JSession.md
+++ b/Docs/en-US/Open-JSession.md
@@ -14,12 +14,12 @@ schema: 2.0.0
 
 ### Default (Default)
 ```
-Open-JSession [-Credential <PSCredential>] [[-Uri] <String>] [<CommonParameters>]
+Open-JSession [-Credential <PSCredential>] [[-Uri] <String>] [-PassThru] [<CommonParameters>]
 ```
 
 ### Save
 ```
-Open-JSession -Credential <PSCredential> [-Uri] <String> [-Save] [<CommonParameters>]
+Open-JSession -Credential <PSCredential> [-Uri] <String> [-Save] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,6 +57,21 @@ Parameter Sets: Save
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+{{ Fill PassThru Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Docs/en-US/Remove-JIssue.md
+++ b/Docs/en-US/Remove-JIssue.md
@@ -12,14 +12,14 @@ schema: 2.0.0
 
 ## SYNTAX
 
-### IssueID (Default)
+### InputObject (Default)
 ```
-Remove-JIssue [-Key] <String[]> [<CommonParameters>]
+Remove-JIssue -InputObject <Issue> [<CommonParameters>]
 ```
 
-### InputObject
+### IssueID
 ```
-Remove-JIssue [-InputObject] <Issue> [<CommonParameters>]
+Remove-JIssue [-Key] <String[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,7 +45,7 @@ Parameter Sets: InputObject
 Aliases:
 
 Required: True
-Position: 0
+Position: Named
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False

--- a/Docs/en-US/Set-JIssue.md
+++ b/Docs/en-US/Set-JIssue.md
@@ -12,16 +12,16 @@ schema: 2.0.0
 
 ## SYNTAX
 
-### IssueID (Default)
+### InputObject (Default)
 ```
-Set-JIssue [-Key] <String[]> [-Project <String>] [-Assignee <String>] [-Description <String>]
+Set-JIssue -InputObject <Issue> [-Project <String>] [-Assignee <String>] [-Description <String>]
  [-Reporter <String>] [-Summary <String>] [-Priority <String>] [-Type <String>] [-ParentIssueKey <String>]
  [-CustomField <IDictionary>] [<CommonParameters>]
 ```
 
-### InputObject
+### IssueID
 ```
-Set-JIssue [-InputObject] <Issue> [-Project <String>] [-Assignee <String>] [-Description <String>]
+Set-JIssue [-Key] <String[]> [-Project <String>] [-Assignee <String>] [-Description <String>]
  [-Reporter <String>] [-Summary <String>] [-Priority <String>] [-Type <String>] [-ParentIssueKey <String>]
  [-CustomField <IDictionary>] [<CommonParameters>]
 ```
@@ -94,7 +94,7 @@ Parameter Sets: InputObject
 Aliases:
 
 Required: True
-Position: 0
+Position: Named
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: False

--- a/Tests/Close-JSession.Tests.ps1
+++ b/Tests/Close-JSession.Tests.ps1
@@ -1,0 +1,21 @@
+Describe "function Close-JSession" -Tag Integration {
+    BeforeEach {
+        Open-JSession
+        $session = Get-JSession
+        $session.IsConnected | Should -BeTrue
+    }
+
+    It "Closes a JSession" {
+        Close-JSession
+        $session.IsConnected | Should -BeFalse
+        $session2 = Get-JSession
+        $session2 | Should -BeNullOrEmpty
+    }
+
+    It "Closes a JSession over pipeline" {
+        $session | Close-JSession
+        $session.IsConnected | Should -BeFalse
+        $session2 = Get-JSession
+        $session2 | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Get-JSession.Tests.ps1
+++ b/Tests/Get-JSession.Tests.ps1
@@ -1,0 +1,11 @@
+Describe "function Get-JIssue" -Tag Integration {
+    BeforeAll {
+        Open-JSession
+
+    }
+
+    It "Gets a JSession" {
+        $result = Get-JSession
+        $result | Should -Not -BeNullOrEmpty
+    }
+}

--- a/Tests/Invoke-JIssueTransition.Tests.ps1
+++ b/Tests/Invoke-JIssueTransition.Tests.ps1
@@ -14,13 +14,13 @@ Describe "function Invoke-JIssueTransition" -Tag Integration {
         }
     }
 
-    It "Transition by ID" {
+    It "Transition by ID (by position)" {
 
         $issue.Status | Should -Be 'Open' -Because "We need a known starting point"
-        Invoke-JIssueTransition -ID $ticket -TransitionTo "In Progress"
+        Invoke-JIssueTransition $ticket -TransitionTo "In Progress"
         $issue.Refresh()
         $issue.Status | Should -Be 'In Progress'
-        Invoke-JIssueTransition -ID $ticket -TransitionTo "Open"
+        Invoke-JIssueTransition $ticket -TransitionTo "Open"
         $issue.Refresh()
         $issue.Status | Should -Be 'Open'
     }
@@ -45,7 +45,7 @@ Describe "function Invoke-JIssueTransition" -Tag Integration {
         } | Should -Throw -ExceptionType ([JiraModule.JiraInvalidActionException])
     }
 
-    It "Transition invalid status should throw" {
+    It "Transition invalid status by pipeline should throw" {
         {
             $issue | Invoke-JIssueTransition -TransitionTo "INVALID_STATUS"
         } | Should -Throw -ExceptionType ([JiraModule.JiraInvalidActionException])

--- a/Tests/New-JIssue.Tests.ps1
+++ b/Tests/New-JIssue.Tests.ps1
@@ -9,8 +9,9 @@ Describe "function New-JIssue" -Tag Integration {
             Summary = "test ticket 1"
             Project = $Project
             Type    = "New Feature"
+            Description = "jira test ticket"
         }
-        $issue = New-JIssue @newIssueSplat
+        $issue = New-JIssue @newIssueSplat -Verbose
         $issueID = $issue.Key
         $issue | Should -Not -BeNullOrEmpty
         $issue | Remove-JIssue

--- a/Tests/Remove-JIssue.Tests.ps1
+++ b/Tests/Remove-JIssue.Tests.ps1
@@ -4,16 +4,52 @@ Describe "function Remove-JIssue" -Tag Integration {
         $Project = "LDDTFT"
     }
 
-    It "Creates a ticket" {
+    It "Removes a ticket by InputObject" {
         $newIssueSplat = @{
-            Summary = "test ticket 2"
+            Summary = "test Remove-Issue ticket 1"
             Project = $Project
             Type    = "New Feature"
+            Description = "Test ticket creation"
         }
         $issue = New-JIssue @newIssueSplat
         $issueID = $issue.Key
         $issue | Should -Not -BeNullOrEmpty
+        Remove-JIssue -InputObject $issue
+        $issue2 = Get-JIssue -Key $issueID
+        $issue2 | Should -BeNullOrEmpty
+    }
+
+    It "Removes a ticket by ID positionally" {
+        $newIssueSplat = @{
+            Summary = "test Remove-Issue ticket 2"
+            Project = $Project
+            Type    = "New Feature"
+            Description = "Test ticket creation"
+        }
+        $issue = New-JIssue @newIssueSplat
+        $issueID = $issue.Key
+        $issue | Should -Not -BeNullOrEmpty
+        $issueID | Should -Match $Project
+
+        Remove-JIssue $issueID
+
+        $issue2 = Get-JIssue -ID $issueID
+        $issue2 | Should -BeNullOrEmpty
+    }
+
+    It "Removes a ticket over pipeline" {
+        $newIssueSplat = @{
+            Summary = "test Remove-Issue ticket 3"
+            Project = $Project
+            Type    = "New Feature"
+            Description = "Test ticket creation"
+        }
+        $issue = New-JIssue @newIssueSplat
+        $issueID = $issue.Key
+        $issue | Should -Not -BeNullOrEmpty
+
         $issue | Remove-JIssue
+
         $issue2 = Get-JIssue -ID $issueID
         $issue2 | Should -BeNullOrEmpty
     }

--- a/Tests/Save-JIssue.Tests.ps1
+++ b/Tests/Save-JIssue.Tests.ps1
@@ -3,29 +3,37 @@ Describe "function Save-JIssue" -Tag Integration {
         Open-JSession
         $Ticket = "LDDTFT-13"
         $MissingTicket = "MISSING-13"
+
     }
 
     It "Saves custom field value" {
-        $riskLevel = "4"
-        $name = 'Risk Level'
+
+        $value = "kmarquette"
+        $name = 'SDM'
+
+        $issue = Get-JIssue -ID $Ticket
+        $issue[$name] = ""
+
+        $issue | Save-JIssue
+
         $issue = Get-JIssue -ID $Ticket
         $issue2 = Get-JIssue -ID $Ticket
 
-        $issue[$name] | Should -Not -Be $riskLevel -Because "issue should have some other value to start with"
-        $issue2[$name] | Should -Not -Be $riskLevel -Because "issue2 should have some other value to start with"
+        $issue[$name] | Should -Not -Be $value -Because "issue should have some other value to start with"
+        $issue2[$name] | Should -Not -Be $value -Because "issue2 should have some other value to start with"
 
-        $issue[$name] = $riskLevel
+        $issue[$name] = $value
         # throws JiraModule.JiraInvalidActionException, need to fix
         $issue | Save-JIssue
 
-        $issue[$name] | Should -Be $riskLevel
+        $issue[$name] | Should -Be $value
 
-        $issue2[$name] | Should -Not -Be $riskLevel -Because "This is a second local copy that should not auto-update"
+        $issue2[$name] | Should -Not -Be $value -Because "This is a second local copy that should not auto-update"
         $issue2.Refresh()
-        $issue2[$name] | Should -Be $riskLevel
+        $issue2[$name] | Should -Be $value
 
         $issue3 = Get-JIssue -ID $Ticket
-        $issue3[$name] | Should -Be $riskLevel
+        $issue3[$name] | Should -Be $value
     }
 
     It "Sets the description on an issue using the pipe" {

--- a/Tests/Set-JIssue.Tests.ps1
+++ b/Tests/Set-JIssue.Tests.ps1
@@ -8,20 +8,17 @@ Describe "function Set-JIssue" -Tag Integration {
     It "Sets the description on an issue using issue ID" {
         $description = "TEST_DESCRIPTION_1 $(Get-Date)"
         $issue = Get-JIssue -ID $Ticket
-        $issue2 = Get-JIssue -ID $Ticket
 
         $issue.description | Should -Not -Be $description -Because "issue should have some other value to start with"
-        $issue2.description | Should -Not -Be $description -Because "issue2 should have some other value to start with"
 
-        Set-JIssue -Description $description -Verbose -ID $Ticket
+        Set-JIssue  $Ticket -Description $description
+
+        $issue.description | Should -Not -Be $description -Because "This is a second local copy that should not auto-update"
+        $issue.Refresh()
         $issue.description | Should -Be $description
 
-        $issue2.description | Should -Not -Be $description -Because "This is a second local copy that should not auto-update"
-        $issue2.Refresh()
+        $issue2 = Get-JIssue -ID $Ticket
         $issue2.description | Should -Be $description
-
-        $issue3 = Get-JIssue -ID $Ticket
-        $issue3.description | Should -Be $description
     }
 
     It "Sets the description on an issue using the pipe" {
@@ -47,7 +44,7 @@ Describe "function Set-JIssue" -Tag Integration {
     It "Invalid ticket should throw" {
         $description = "TEST_DESCRIPTION_2 $(Get-Date)"
         {
-            Set-JIssue -Description $description -Verbose -ID $MissingTicket
+            Set-JIssue -Description $description -ID $MissingTicket
         } | Should -Throw -ExceptionType ([JiraModule.JiraInvalidActionException])
     }
 }

--- a/jira/jira.psd1
+++ b/jira/jira.psd1
@@ -12,7 +12,7 @@
 RootModule = 'jira.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.2'
+ModuleVersion = '0.3.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -84,6 +84,8 @@ CmdletsToExport = @(
     'Invoke-JIssueTransition'
     'Remove-JIssue'
     'Receive-JAsyncResult'
+    'Get-JSession'
+    'Close-JSession'
 )
 
 # Variables to export from this module

--- a/jira/public/Open-JSession.ps1
+++ b/jira/public/Open-JSession.ps1
@@ -29,7 +29,11 @@ function Open-JSession
             ParameterSetName = 'Save'
         )]
         [switch]
-        $Save
+        $Save,
+
+        [Parameter()]
+        [switch]
+        $PassThru
     )
 
     begin
@@ -68,7 +72,7 @@ function Open-JSession
         }
 
         Write-Verbose "Credential [$($credential.UserName)]"
-        JiraModule\Open-JSession -Credential $Credential -Uri $uri
+        JiraModule\Open-JSession -Credential $Credential -Uri $uri -PassThru:$PassThru
 
         if ($Save)
         {

--- a/src/classes/JSession.cs
+++ b/src/classes/JSession.cs
@@ -1,0 +1,95 @@
+using Atlassian.Jira;
+
+namespace JiraModule {
+    /// <summary>
+    /// Manages access to the Jira API and related connection information
+    /// </summary>
+    /// <notes>
+    /// This is just a friendly wrapper around the JiraRestClient
+    /// No actual connection to the server is established
+    /// These sessions give the illusion of connections
+    /// </notes>
+    public class JSession
+    {
+        protected static Jira api = null;
+
+        /// <summary>
+        /// Atlassian Jira endpoint
+        /// </summary>
+        /// <value></value>
+        internal static Jira Api
+        {
+            get
+            {
+                if (null == api)
+                {
+                    throw new JiraConnectionException();
+                }
+                return api;
+            }
+        }
+
+        /// <summary>
+        /// The Jira server address
+        /// </summary>
+        /// <value></value>
+        public string Uri {
+            get => api?.Url;
+        }
+
+        /// <summary>
+        /// Credential used for authentication
+        /// </summary>
+        /// <value></value>
+        public string UserName {
+            get => api?.Credentials.UserName;
+        }
+
+        /// <summary>
+        /// Raw JiraClient for issuing rest calls
+        /// </summary>
+        /// <value></value>
+        public Jira JiraClient {
+            get => api;
+        }
+
+
+        /// <summary>
+        /// Opens a Jira sessions
+        /// </summary>
+        /// <param name="uri">Jira server</param>
+        /// <param name="username">Jira username</param>
+        /// <param name="password">Jira password</param>
+        /// <notes>Internally creates a Jira RestClient using specified values but does not actually establish a connection.</notes>
+        public static void Open(string uri, string username, string password)
+        {
+            api = Jira.CreateRestClient(uri, username, password);
+        }
+
+        /// <summary>
+        /// Closes the Jira session
+        /// </summary>
+        public static void Close()
+        {
+            api = null;
+        }
+
+        /// <summary>
+        /// Checks to see if a session exists
+        /// </summary>
+        /// <value>true if connected</value>
+        /// <notes>if api is null, then there is no conneciton.</notes>
+        public bool IsConnected {
+            get
+            {
+                return (api != null);
+            }
+        }
+
+        /// <summary>
+        /// Jira Issue Client Actions
+        /// </summary>
+        /// <value></value>
+        internal static IIssueService Issues {get => api.Issues;}
+    }
+}

--- a/src/cmdlets/AddComment.cs
+++ b/src/cmdlets/AddComment.cs
@@ -69,7 +69,7 @@ namespace JiraModule
                 var result = from node in Key
                              select new AsyncAction(
                                  $"Add comment to issue [{node}]",
-                                 JiraApi.Issues.AddCommentAsync(node, comment)
+                                 JSession.Issues.AddCommentAsync(node, comment)
                              );
 
                 startedTasks.AddRange(result);

--- a/src/cmdlets/CloseSession.cs
+++ b/src/cmdlets/CloseSession.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Management.Automation;
+
+namespace JiraModule
+{
+    [Cmdlet(VerbsCommon.Close, "JSession")]
+    public class CloseSession : JiraCmdlet
+    {
+        /// <summary>
+        /// Session to close
+        /// </summary>
+        /// <value>A current session</value>
+        /// <notes>For illusion of pipeline support, not actually used</notes>
+        [Parameter(
+            Position = 0,
+            ValueFromPipeline = true
+        )]
+        public JSession Session { get; set; }
+
+        protected override void EndProcessing()
+        {
+            JSession.Close();
+        }
+    }
+}

--- a/src/cmdlets/GetIssue.cs
+++ b/src/cmdlets/GetIssue.cs
@@ -81,21 +81,21 @@ namespace JiraModule
                     string issueID = InputObject.Key.ToString();
                     message = $"Starting query for [{issueID}] from InputObject";
                     WriteVerbose(message);
-                    var task = JiraApi.Issues.GetIssueAsync(issueID);
+                    var task = JSession.Issues.GetIssueAsync(issueID);
                     queryResult = new AsyncResult(message,task);
                     break;
 
                 case "Query":
                     message = $"Starting JQL query [{Query}]";
                     WriteVerbose(message);
-                    var queryTask = JiraApi.Issues.GetIssuesFromJqlAsync(Query, MaxResults, StartAt);
+                    var queryTask = JSession.Issues.GetIssuesFromJqlAsync(Query, MaxResults, StartAt);
                     queryResult = new AsyncResult(message,queryTask);
                     break;
 
                 default:
                     message = $"Starting query for [{Key}]";
                     WriteVerbose(message);
-                    var jiraTask = JiraApi.Issues.GetIssuesAsync(Key);
+                    var jiraTask = JSession.Issues.GetIssuesAsync(Key);
                     queryResult = new AsyncResult(
                         message,
                         jiraTask,

--- a/src/cmdlets/GetSession.cs
+++ b/src/cmdlets/GetSession.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Management.Automation;
+using Atlassian.Jira;
+
+namespace JiraModule
+{
+    [Cmdlet(VerbsCommon.Get, "JSession")]
+    public class GetSession : JiraCmdlet
+    {
+        protected override void EndProcessing()
+        {
+            var session = new JSession();
+            if (session.IsConnected)
+            {
+                WriteObject(session);
+            }
+            else
+            {
+                WriteVerbose("No Jira session is available.");
+            }
+        }
+    }
+}

--- a/src/cmdlets/InvokeIssueTransition.cs
+++ b/src/cmdlets/InvokeIssueTransition.cs
@@ -15,7 +15,7 @@ namespace JiraModule
     [Cmdlet(
         VerbsLifecycle.Invoke,
         "JIssueTransition",
-        DefaultParameterSetName = "IssueID"
+        DefaultParameterSetName = "InputObject"
     )]
     [OutputType(typeof(Atlassian.Jira.Issue))]
     [OutputType(typeof(JiraModule.AsyncResult))]
@@ -37,7 +37,6 @@ namespace JiraModule
         /// </summary>
         [Parameter(
             Mandatory = true,
-            Position = 0,
             ValueFromPipeline = true,
             ParameterSetName = "InputObject"
         )]
@@ -63,7 +62,11 @@ namespace JiraModule
             if (ParameterSetName == "IssueID")
             {
                 // make this more async
-                var issues = JiraApi.Issues.GetIssuesAsync(Key).GetAwaiter().GetResult();
+                var issues = JSession.Issues.GetIssuesAsync(Key).GetAwaiter().GetResult();
+                if(null == issues || issues.Count == 0)
+                {
+                    throw new JiraInvalidActionException($"No issue found matching key [{Key}]");
+                }
                 foreach (Issue issue in issues.Values)
                 {
                     message = $"Transitioning issue [{issue.Key}] to [{TransitionTo}]";

--- a/src/cmdlets/JiraCmdlet.cs
+++ b/src/cmdlets/JiraCmdlet.cs
@@ -10,27 +10,6 @@ namespace JiraModule
     /// </summary>
     public class JiraCmdlet : PSCmdlet
     {
-        /// <summary>
-        /// This is set by calls to Open-JiraSession
-        /// </summary>
-        protected static Jira jiraApi = null;
-        protected Jira JiraApi
-        {
-            get
-            {
-                if (null == jiraApi)
-                {
-                    ThrowTerminatingError(
-                        new ErrorRecord(
-                            new JiraConnectionException(),
-                            "TestConnectionException",
-                            ErrorCategory.ConnectionError,
-                            null
-                        )
-                    );
-                }
-                return jiraApi;
-            }
-        }
+
     }
 }

--- a/src/cmdlets/NewIssue.cs
+++ b/src/cmdlets/NewIssue.cs
@@ -68,7 +68,7 @@ namespace JiraModule
         //pipeline to this cmdlet; if no input is received, this method is not called
         protected override void ProcessRecord()
         {
-            var issue = new Issue(JiraApi,Project,ParentIssueKey);
+            var issue = new Issue(JSession.Api,Project,ParentIssueKey);
             if( null != Assignee )
             {
                 issue.Assignee = Assignee;
@@ -96,10 +96,10 @@ namespace JiraModule
             // Create issue only returns the Key, so we also need the object
             var result = new AsyncResult(
                 $"Get new issue from project [{Project}]",
-                jiraApi.Issues.GetIssueAsync(
+                JSession.Issues.GetIssueAsync(
                     new AsyncResult(
                         $"Create new issue in project [{Project}]",
-                        JiraApi.Issues.CreateIssueAsync(issue)
+                        JSession.Issues.CreateIssueAsync(issue)
                     ).GetResult()
                 )
             );

--- a/src/cmdlets/OpenSession.cs
+++ b/src/cmdlets/OpenSession.cs
@@ -10,7 +10,7 @@ namespace JiraModule
 {
     [Alias("Open-JiraSession")]
     [Cmdlet(VerbsCommon.Open, "JSession")]
-    public class JiraSession : JiraCmdlet
+    public class OpenSession : JiraCmdlet
     {
 
         [Parameter(
@@ -33,12 +33,12 @@ namespace JiraModule
 
         protected override void EndProcessing()
         {
-            WriteVerbose($"Connectiong to Jira endpoint [{Uri}] with username [{Credential.UserName}]");
+            WriteVerbose($"Connection to Jira endpoint [{Uri}] with username [{Credential.UserName}]");
             CreateClient();
 
             if (PassThru)
             {
-                WriteObject(JiraApi);
+                WriteObject(new JSession());
             }
         }
 
@@ -52,18 +52,18 @@ namespace JiraModule
                 string message = $"Connecting to Jira Endpoint [{Uri}] with Username [{Credential.UserName}]";
                 WriteVerbose(message);
 
-                JiraSession.jiraApi = Jira.CreateRestClient(Uri, username, password);
+                JSession.Open(Uri, username, password);
 
                 WriteDebug("Issuing basic request to verify connectivity [Get Priorities]");
                 new AsyncResult(
                     message,
-                    JiraApi.Priorities.GetPrioritiesAsync()
+                    JSession.Api.Priorities.GetPrioritiesAsync()
                 ).Wait();
             }
             catch (Exception ex)
             {
                 // clear invalid session
-                JiraSession.jiraApi = null;
+                JSession.Close();
                 throw new JiraConnectionException(ex.Message,ex);
             }
         }

--- a/src/cmdlets/RemoveIssue.cs
+++ b/src/cmdlets/RemoveIssue.cs
@@ -14,7 +14,7 @@ namespace JiraModule
     /// <notes>
     /// </notes>
     [Alias("Remove-Issue")]
-    [Cmdlet(VerbsCommon.Remove, "JIssue", DefaultParameterSetName = "IssueID")]
+    [Cmdlet(VerbsCommon.Remove, "JIssue", DefaultParameterSetName = "InputObject")]
     [OutputType(typeof(Atlassian.Jira.Issue))]
     [OutputType(typeof(JiraModule.AsyncResult))]
     public class RemoveIssue : JiraCmdlet
@@ -35,7 +35,6 @@ namespace JiraModule
         /// </summary>
         [Parameter(
             Mandatory = true,
-            Position = 0,
             ValueFromPipeline = true,
             ParameterSetName = "InputObject"
         )]
@@ -45,6 +44,7 @@ namespace JiraModule
         //pipeline to this cmdlet; if no input is received, this method is not called
         protected override void ProcessRecord()
         {
+            WriteVerbose($"ParameterSetName [{ParameterSetName}]");
             if(ParameterSetName == "InputObject")
             {
                 string message = $"Removing issue [{InputObject.Key}]";
@@ -54,16 +54,17 @@ namespace JiraModule
                 startedTasks.Add(
                     new AsyncResult(
                         message,
-                        jiraApi.Issues.DeleteIssueAsync(issueID)
+                        JSession.Issues.DeleteIssueAsync(issueID)
                     )
                 );
             }
             else
             {
+                WriteVerbose("Removing issue by ID");
                 var results = from node in Key
                     select new AsyncResult(
-                        $"Removing issue [{InputObject.Key}]",
-                        jiraApi.Issues.DeleteIssueAsync(node)
+                        $"Removing issue [{node}]",
+                        JSession.Issues.DeleteIssueAsync(node)
                     );
 
                 startedTasks.AddRange(results);


### PR DESCRIPTION
Add `-PassThru` parameter to `Open-JSession`
Add `Get-JSession` command
Add `Close-JSession` command
Reworked default parameter set to support piping Issues and passing keys

fix `NullRefrenceException` when calling `Set-JIssue` with issue key
fix `NullRefrenceException` when calling `Remove-JIssue` with issue key
add exception when calling `Invoke-JIssueTransition` with invalid issue key

All public functions have unit tests
100% integration test passing
